### PR TITLE
Support Result as class to enable access to full property list

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $exchange->symbols('USD', 'EUR', 'GBP');
 
 Use whatever method fills your needs.
 
-## Reponse
+## Response
 
 The response is a simple array with currencies as keys and ratios as values. For a request like the following:
 
@@ -91,13 +91,23 @@ print $rates['EUR'];
 print $rates[Currency::GBP];
 ```
 
-The last option, probably more preferable by some, is handling the response as an object:
+There is an option to handle the response as an object:
 
 ```php
 $rates = (new Exchange())->symbols(Currency::USD, Currency::GBP)->getAsObject();
 
 print $rates->USD;
 print $rates->GBP;
+```
+
+The last option is to return the response as a `Result` class. This allows access to the full set of properties returned from the feed. 
+
+```php
+$result = (new Exchange())->symbols(Currency::USD, Currency::GBP)->getAsObject();
+
+$date = $result->getDate(); // The date the data is from
+$rates = $result->getRates(); // Array of rates as above
+$usd = $result->getRate(Currency::USD); // Will return null if there was no value
 ```
 
 ## Error Handling

--- a/src/Result.php
+++ b/src/Result.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Fadion\Fixerio;
+
+use DateTime;
+
+class Result
+{
+    /**
+     * The Base currency the result was returned in
+     * @var string
+     */
+    private $base;
+
+    /**
+     * The date the result was generated
+     * @var DateTime
+     */
+    private $date;
+
+    /**
+     * All of the rates returned
+     * @var array
+     */
+    private $rates;
+
+    /**
+     * Result constructor.
+     *
+     * @param string $base
+     * @param DateTime $date
+     * @param array $rates
+     */
+    public function __construct($base, DateTime $date, $rates)
+    {
+        $this->base = $base;
+        $this->date = $date;
+        $this->rates = $rates;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBase()
+    {
+        return $this->base;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRates()
+    {
+        return $this->rates;
+    }
+
+    /**
+     * Get an individual rate by Currency code
+     * Will return null if currency is not found in the result
+     *
+     * @param string $code
+     * @return float|null
+     */
+    public function getRate($code)
+    {
+        if (isset($this->rates[$code])) {
+            return $this->rates[$code];
+        }
+        return null;
+    }
+}

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Fadion\Fixerio\Currency;
+use Fadion\Fixerio\Result;
+
+class ResultTest extends PHPUnit_Framework_TestCase
+{
+    public function testGetters()
+    {
+        $rates = [
+            Currency::USD => 1.23,
+            Currency::GBP => 1.01,
+        ];
+        $base = 'EUR';
+        $date = new DateTime('2016-01-02');
+
+        $result = new Result($base, $date, $rates);
+
+        $this->assertEquals($rates, $result->getRates());
+        $this->assertEquals($base, $result->getBase());
+        $this->assertEquals($date, $result->getDate());
+
+        $this->assertEquals(1.23, $result->getRate(Currency::USD));
+        $this->assertEquals(1.01, $result->getRate(Currency::GBP));
+        $this->assertNull($result->getRate(Currency::HKD));
+        $this->assertNull($result->getRate('invalid'));
+    }
+}


### PR DESCRIPTION
Sometimes the Fixer.io result may have been generated on a date earlier than what you ask for. For example: https://api.fixer.io/2016-07-10
This change creates a `Result` object out of the whole feed, so that the date can be compared to what was expected, and then the rates read.
This is a new method, so everything is backwards compatible with what existed before.