### PR TITLE
New domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ use Fadion\Fixerio\Exchange;
 use Fadion\Fixerio\Currency;
 
 $exchange = new Exchange();
+$exchange->key("YOUR_ACCESS_KEY");
 $exchange->base(Currency::USD);
 $exchange->symbols(Currency::EUR, Currency::GBP);
 
@@ -38,13 +39,14 @@ By default, the base currency is `EUR`, so if that's your base, there's no need 
 A simplified example without the base and currency:
 
 ```php
-$rates = (new Exchange())->get();
+$rates = (new Exchange())->key("YOUR_ACCESS_KEY")->get();
 ```
 
 The `historical` option will return currency rates for every day since the date you've specified. The base currency and symbols can be omitted here to, but let's see a full example:
 
 ```php
 $exchange = new Exchange();
+$exchange->key("YOUR_ACCESS_KEY");
 $exchange->historical('2012-12-12');
 $exchange->base(Currency::AUD);
 $exchange->symbols(Currency::USD, Currency::EUR, Currency::GBP);
@@ -75,7 +77,7 @@ Use whatever method fills your needs.
 The response is a simple array with currencies as keys and ratios as values. For a request like the following:
 
 ```php
-$rates = (new Exchange())->symbols(Currency::USD, Currency::GBP)->get();
+$rates = (new Exchange())->key("YOUR_ACCESS_KEY")->symbols(Currency::USD, Currency::GBP)->get();
 ```
 
 the response will be an array:
@@ -94,7 +96,7 @@ print $rates[Currency::GBP];
 There is an option to handle the response as an object:
 
 ```php
-$rates = (new Exchange())->symbols(Currency::USD, Currency::GBP)->getAsObject();
+$rates = (new Exchange())->key("YOUR_ACCESS_KEY")->symbols(Currency::USD, Currency::GBP)->getAsObject();
 
 print $rates->USD;
 print $rates->GBP;
@@ -103,7 +105,7 @@ print $rates->GBP;
 The last option is to return the response as a `Result` class. This allows access to the full set of properties returned from the feed. 
 
 ```php
-$result = (new Exchange())->symbols(Currency::USD, Currency::GBP)->getResult();
+$result = (new Exchange())->key("YOUR_ACCESS_KEY")->symbols(Currency::USD, Currency::GBP)->getResult();
 
 $date = $result->getDate(); // The date the data is from
 $rates = $result->getRates(); // Array of rates as above
@@ -121,6 +123,7 @@ use Fadion\Fixerio\Exceptions\ResponseException;
 
 try {
     $exchange = new Exchange();
+    $exchange->key("YOUR_ACCESS_KEY");
     $rates = $exchange->get();
 }
 catch (ConnectionException $e) {
@@ -140,4 +143,12 @@ use Exchange;
 use Fadion\Fixerio\Currency;
 
 $rates = Exchange::base(Currency::USD)->get();
+```
+
+To use this Facade, you should set your access key in your `config/services.php` file:
+
+```php
+'fixer'=>[
+    'key'=>env("FIXER_ACCESS_KEY"),
+]
 ```

--- a/src/Exchange.php
+++ b/src/Exchange.php
@@ -54,6 +54,13 @@ class Exchange
     private $asObject = false;
 
     /**
+     * Holds the Fixer.io API key
+     *
+     * @var null|string
+     */
+    private $key = null;
+
+    /**
      * @param $guzzle Guzzle client
      */
     public function __construct($guzzle = null)
@@ -86,6 +93,19 @@ class Exchange
     public function base($currency)
     {
         $this->base = $currency;
+
+        return $this;
+    }
+
+    /**
+     * Sets the API key
+     *
+     * @param  string $key
+     * @return Exchange
+     */
+    public function key($key)
+    {
+        $this->key = $key;
 
         return $this;
     }

--- a/src/Exchange.php
+++ b/src/Exchange.php
@@ -20,7 +20,7 @@ class Exchange
      * URL of fixer.io
      * @var string
      */
-    private $url = "api.fixer.io";
+    private $url = "data.fixer.io/api";
 
     /**
      * Date when an historical call is made

--- a/src/Exchange.php
+++ b/src/Exchange.php
@@ -235,6 +235,10 @@ class Exchange
 
         $url .= '?base=' . $this->base;
 
+        if ($this->key) {
+            $url .= '&access_key=' . $this->key;
+        }
+
         if ($symbols = $this->symbols) {
             $url .= '&symbols=' . implode(',', $symbols);
         }

--- a/src/Exchange.php
+++ b/src/Exchange.php
@@ -3,8 +3,8 @@
 namespace Fadion\Fixerio;
 
 use DateTime;
-use Fadion\Fixerio\Exceptions\ResponseException;
 use Fadion\Fixerio\Exceptions\ConnectionException;
+use Fadion\Fixerio\Exceptions\ResponseException;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\TransferException;
 
@@ -60,8 +60,7 @@ class Exchange
     {
         if (isset($guzzle)) {
             $this->guzzle = $guzzle;
-        }
-        else {
+        } else {
             $this->guzzle = new GuzzleClient();
         }
     }
@@ -154,7 +153,7 @@ class Exchange
         }
         // The client needs to know only one exception, no
         // matter what exception is thrown by Guzzle
-        catch (TransferException $e) {
+         catch (TransferException $e) {
             throw new ConnectionException($e->getMessage());
         }
     }
@@ -178,7 +177,7 @@ class Exchange
         }
         // The client needs to know only one exception, no
         // matter what exception is thrown by Guzzle
-        catch (TransferException $e) {
+         catch (TransferException $e) {
             throw new ConnectionException($e->getMessage());
         }
     }
@@ -206,19 +205,18 @@ class Exchange
      */
     private function buildUrl($url)
     {
-        $url = $this->protocol.'://'.$url.'/';
+        $url = $this->protocol . '://' . $url . '/';
 
         if ($this->date) {
             $url .= $this->date;
-        }
-        else {
+        } else {
             $url .= 'latest';
         }
 
-        $url .= '?base='.$this->base;
+        $url .= '?base=' . $this->base;
 
         if ($symbols = $this->symbols) {
-            $url .= '&symbols='.implode(',', $symbols);
+            $url .= '&symbols=' . implode(',', $symbols);
         }
 
         return $url;
@@ -248,11 +246,9 @@ class Exchange
 
         if (isset($response['rates']) and is_array($response['rates'])) {
             return ($this->asObject) ? (object) $response['rates'] : $response['rates'];
-        }
-        else if (isset($response['error'])) {
+        } else if (isset($response['error'])) {
             throw new ResponseException($response['error']);
-        }
-        else {
+        } else {
             throw new ResponseException('Response body is malformed.');
         }
     }
@@ -273,11 +269,9 @@ class Exchange
                 new DateTime($response['date']),
                 $response['rates']
             );
-        }
-        else if (isset($response['error'])) {
+        } else if (isset($response['error'])) {
             throw new ResponseException($response['error']);
-        }
-        else {
+        } else {
             throw new ResponseException('Response body is malformed.');
         }
     }

--- a/src/ExchangeServiceProvider.php
+++ b/src/ExchangeServiceProvider.php
@@ -21,7 +21,7 @@ class ExchangeServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton(Exchange::class, function ($app) {
-            return new Exchange;
+            return (new Exchange)->key(config("services.fixer.key"));
         });
     }
 


### PR DESCRIPTION
Fixer updated it's pricing model and domain name, and will require an api key for any lookups at the beginning of June (see https://github.com/fixerAPI/fixer). In the meantime, rate limiting is now applied on the deprecated domain. I made a few edits by adding a `$key` variable to the Exchange class and updating it's base domain so I could keep using Fixer in a project currently in production. Feel free to use any parts of this if needed :)