### PR TITLE
updated the url used for testing

### DIFF
--- a/tests/ExchangeTest.php
+++ b/tests/ExchangeTest.php
@@ -6,7 +6,7 @@ use Fadion\Fixerio\Exchange;
 
 class ExchangeTest extends PHPUnit_Framework_TestCase
 {
-    private $url = 'http://api.fixer.io';
+    private $url = 'http://data.fixer.io/api';
 
     public function tearDown()
     {


### PR DESCRIPTION
The URL listed in the phpunit test class did not match what was used in the Exchange class. Tests are now passing.