### PR TITLE
Corrected bug in prepareResponseResult

### DIFF
--- a/src/Exchange.php
+++ b/src/Exchange.php
@@ -293,8 +293,8 @@ class Exchange
                 new DateTime($response['date']),
                 $response['rates']
             );
-        } else if (isset($response['error'])) {
-            throw new ResponseException($response['error']);
+        } else if (isset($response['error']['info'])) {
+            throw new ResponseException($response['error']['info']);
         } else {
             throw new ResponseException('Response body is malformed.');
         }


### PR DESCRIPTION
$response['error'] is an array while we need a string to raise a ResponseException