### PR TITLE
Updated facade to return correct accessor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require-dev": {
         "mockery/mockery": "dev-master",
-        "phpunit/phpunit": "4.8.*"
+        "phpunit/phpunit": "4.8.*",
+        "illuminate/support": "^5.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Facades/Exchange.php
+++ b/src/Facades/Exchange.php
@@ -14,6 +14,9 @@ class Exchange extends Facade
      *
      * @return string
      */
-    protected static function getFacadeAccessor() { return 'exchange'; }
+    protected static function getFacadeAccessor()
+    {
+        return \Fadion\Fixerio\Exchange::class;
+    }
 
 }

--- a/tests/LaravelIntegrationTest.php
+++ b/tests/LaravelIntegrationTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Fadion\Fixerio\ExchangeServiceProvider;
+use Fadion\Fixerio\Facades\Exchange as Facade;
+
+class LaravelIntegrationTest extends \PHPUnit\Framework\TestCase
+{
+    public function testServiceProviderProvidesFacadeAccessor()
+    {
+        $provides = (new ExchangeServiceProvider(null))->provides();
+
+        $app = array_combine($provides, $provides);
+
+        Facade::setFacadeApplication($app);
+
+        $this->assertContains(Facade::getFacadeRoot(), $provides);
+    }
+}


### PR DESCRIPTION
Laravel facades expect that the facade accessor is "provided" by one of
the service providers. Tests have been added to ensure that the service
provider will always provide the correct accessor.

Fixes #11 